### PR TITLE
no-shadow rule false positive

### DIFF
--- a/typescript/index.js
+++ b/typescript/index.js
@@ -15,7 +15,9 @@ module.exports = {
         'ts': 'never',
         'tsx': 'never'
       }
-    ]
+    ],
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": ["error"],
   },
   settings: {
     'import/resolver': {


### PR DESCRIPTION
When using `react-typescript-recommended`, the no-shadow rule gave a false positive. Turns out the rule needs to be deactivated and replaced with a Typescript specific version.

For more, see https://github.com/typescript-eslint/typescript-eslint/issues/2484